### PR TITLE
Fix parallel distance ratio

### DIFF
--- a/src/tools/parallelDistanceTool/addNewMeasurement.js
+++ b/src/tools/parallelDistanceTool/addNewMeasurement.js
@@ -82,6 +82,18 @@ export default function(evt, interactionType) {
 
         triggerEvent(element, EVENTS.MEASUREMENT_MODIFIED, modifiedEventData);
         triggerEvent(element, EVENTS.MEASUREMENT_COMPLETED, modifiedEventData);
+
+        // send imex finish event
+        const eventType = EVENTS.MEASUREMENT_FINISHED;
+        if (measurementData.complete) {
+          const endEventData = {
+            toolType: this.name,
+            element: element,
+            measurementData: measurementData
+          };
+          triggerEvent(element, eventType, endEventData);
+        }
+
       },
     },
     interactionType

--- a/src/tools/parallelDistanceTool/renderToolData.js
+++ b/src/tools/parallelDistanceTool/renderToolData.js
@@ -12,7 +12,8 @@ import {
   setShadow,
   drawLine,
 } from './../../util/drawing.js';
-import drawLinkedTextBox from './../../util/drawLinkedTextBox.js';
+import drawTextBox from './../../util/drawTextBox.js';
+import drawLink from './../../util/drawLink.js';
 import getPixelSpacing from './../../util/getPixelSpacing';
 
 export default function(evt) {
@@ -103,8 +104,8 @@ export default function(evt) {
       // Draw the textbox
       // Move the textbox slightly to the right and upwards
       // So that it sits beside the length tool handle
-      const xOffset = 0;
-      // const yOffset = 20;
+      const xOffset = 180;
+      const yOffset = 160;
       let textBoxAnchorPoints = handles => [handles.start, handles.end];
       const intersectionPoints = getIntersectionPoints(data);
       const intersectionP1 = intersectionPoints[0];
@@ -121,7 +122,7 @@ export default function(evt) {
 
       const textLines = getTextBoxText(data, rowPixelSpacing, colPixelSpacing);
 
-      drawLinkedTextBox(
+      drawParallelTextBox(
         context,
         element,
         textBox,
@@ -131,6 +132,7 @@ export default function(evt) {
         color,
         lineWidth,
         xOffset,
+        yOffset,
         true
       );
     });
@@ -211,3 +213,35 @@ const getIntersectionPoints = data => {
   );
   return [intersectionP1, intersectionP2];
 };
+
+const drawParallelTextBox = (context, element, textBox, text, handles, textBoxAnchorPoints,
+   color, lineWidth, xOffset, yOffset, yCenter) => {
+  
+  const cornerstone = external.cornerstone;
+  // Convert the textbox Image coordinates into Canvas coordinates
+  const textCoords = cornerstone.pixelToCanvas(element, textBox);
+
+  if (xOffset) {
+    textCoords.x += xOffset;
+    textCoords.y += yOffset;
+  }
+
+  const options = {
+    centering: {
+      x: false,
+      y: false
+    }
+  };
+
+  // Draw the text box
+  textBox.boundingBox = drawTextBox(context, text, textCoords.x, textCoords.y, color, options);
+  if (textBox.hasMoved) {
+    // Identify the possible anchor points for the tool -> text line
+    const linkAnchorPoints = textBoxAnchorPoints(handles).map((h) => cornerstone.pixelToCanvas(element, h));
+
+    // Draw dashed link line between tool and text
+    drawLink(linkAnchorPoints, textCoords, textBox.boundingBox, context, color, lineWidth);
+  }
+}
+
+

--- a/src/tools/parallelDistanceTool/utils/updatePerpendicularLineHandles.js
+++ b/src/tools/parallelDistanceTool/utils/updatePerpendicularLineHandles.js
@@ -21,8 +21,8 @@ export default function(eventData, data) {
       y: (start.y + end.y) / 2,
     };
     // Length of long-axis
-    const dx = (start.x - end.x) * (eventData.image.columnPixelSpacing || 1);
-    const dy = (start.y - end.y) * (eventData.image.rowPixelSpacing || 1);
+    const dx = (start.x - end.x);
+    const dy = (start.y - end.y);
     const length = Math.sqrt(dx * dx + dy * dy);
 
     const baseline_angle = Math.abs(Math.atan2(dy, dx));
@@ -48,13 +48,13 @@ export default function(eventData, data) {
 
     startX_p1 = start.x - dx / 4 - dx_perpenticular / 8;
     startY_p1 = start.y - dy / 4 - dy_perpenticular / 8;
-    endX_p1 = start.x - dx / 4 + dx_perpenticular;
-    endY_p1 = start.y - dy / 4 + dy_perpenticular;
+    endX_p1 = start.x - dx / 4 + dx_perpenticular / 2;
+    endY_p1 = start.y - dy / 4 + dy_perpenticular / 2;
 
     startX_p2 = start.x - (dx * 3) / 4 - dx_perpenticular / 8;
     startY_p2 = start.y - (dy * 3) / 4 - dy_perpenticular / 8;
-    endX_p2 = start.x - (dx * 3) / 4 + dx_perpenticular;
-    endY_p2 = start.y - (dy * 3) / 4 + dy_perpenticular;
+    endX_p2 = start.x - (dx * 3) / 4 + dx_perpenticular / 2;
+    endY_p2 = start.y - (dy * 3) / 4 + dy_perpenticular / 2;
   }
   data.handles.perpendicularStart.x = startX_p1;
   data.handles.perpendicularStart.y = startY_p1;


### PR DESCRIPTION
Fix: Change the measurement creation parameters to pixels instead of mm.
Fix: Change label of the parallel distance tool location
Fix: Add measurement finished event