### PR TITLE
Fix "lock" option for new tools

### DIFF
--- a/src/tools/bidirectionalTool/addNewMeasurement.js
+++ b/src/tools/bidirectionalTool/addNewMeasurement.js
@@ -11,6 +11,7 @@ import triggerEvent from './../../util/triggerEvent.js';
 import getActiveTool from './../../util/getActiveTool';
 import baseAnnotationTool from './../../base/baseAnnotationTool';
 
+
 export default function(evt, interactionType) {
   const eventData = evt.detail;
   const { element, image, buttons } = eventData;
@@ -39,63 +40,18 @@ export default function(evt, interactionType) {
     this.name,
     measurementData,
     end,
-    {
-      doneMovingCallback: () => {
-        const { handles, longestDiameter, shortestDiameter } = measurementData;
-        const hasHandlesOutside = anyHandlesOutsideImage(eventData, handles);
-        const longestDiameterSize = parseFloat(longestDiameter) || 0;
-        const shortestDiameterSize = parseFloat(shortestDiameter) || 0;
-        const isTooSmal = longestDiameterSize < 1 || shortestDiameterSize < 1;
-        const isTooFast = new Date().getTime() - timestamp < 150;
+    () => {      
+      const endEventData = {
+        toolType: this.name,
+        element: element,
+        measurementData: measurementData
+      };
+      triggerEvent(element, EVENTS.MEASUREMENT_COMPLETED, endEventData);
 
-        if (hasHandlesOutside || isTooSmal || isTooFast) {
-          // Delete the measurement
-          measurementData.cancelled = true;
-          removeToolState(element, this.name, measurementData);
-        } else {
-          // Set lesionMeasurementData Session
-          config.getMeasurementLocationCallback(
-            measurementData,
-            eventData,
-            doneCallback
-          );
-        }
-
-        // Perpendicular line is not connected to long-line
-        perpendicularStart.locked = false;
-
-        measurementData.invalidated = true;
-
-        external.cornerstone.updateImage(element);
-
-        const activeTool = getActiveTool(element, buttons, interactionType);
-
-        if (activeTool instanceof baseAnnotationTool) {
-          activeTool.updateCachedStats(image, element, measurementData);
-        }
-
-        const modifiedEventData = {
-          toolType: this.name,
-          element,
-          measurementData,
-        };
-
-        triggerEvent(element, EVENTS.MEASUREMENT_MODIFIED, modifiedEventData);
-        triggerEvent(element, EVENTS.MEASUREMENT_COMPLETED, modifiedEventData);
-
-        // send imex finish event
-        const eventType = EVENTS.MEASUREMENT_FINISHED;
-        if (measurementData.complete) {
-          const endEventData = {
-            toolType: this.name,
-            element: element,
-            measurementData: measurementData
-          };
-          triggerEvent(element, eventType, endEventData);
-        }
-      },
-    },
-    interactionType
+      // send imex finish event
+      triggerEvent(element, EVENTS.MEASUREMENT_FINISHED, endEventData);
+      external.cornerstone.updateImage(element);
+    }
   );
 }
 

--- a/src/tools/cardiothoracicIndexTool/addNewMeasurement.js
+++ b/src/tools/cardiothoracicIndexTool/addNewMeasurement.js
@@ -39,63 +39,18 @@ export default function(evt, interactionType) {
     this.name,
     measurementData,
     end,
-    {
-      doneMovingCallback: () => {
-        const { handles, longestDiameter, shortestDiameter } = measurementData;
-        const hasHandlesOutside = anyHandlesOutsideImage(eventData, handles);
-        const longestDiameterSize = parseFloat(longestDiameter) || 0;
-        const shortestDiameterSize = parseFloat(shortestDiameter) || 0;
-        const isTooSmal = longestDiameterSize < 1 || shortestDiameterSize < 1;
-        const isTooFast = new Date().getTime() - timestamp < 150;
+    () => {      
+      const endEventData = {
+        toolType: this.name,
+        element: element,
+        measurementData: measurementData
+      };
+      triggerEvent(element, EVENTS.MEASUREMENT_COMPLETED, endEventData);
 
-        if (hasHandlesOutside || isTooSmal || isTooFast) {
-          // Delete the measurement
-          measurementData.cancelled = true;
-          removeToolState(element, this.name, measurementData);
-        } else {
-          // Set lesionMeasurementData Session
-          config.getMeasurementLocationCallback(
-            measurementData,
-            eventData,
-            doneCallback
-          );
-        }
-
-        // Perpendicular line is not connected to long-line
-        perpendicularStart.locked = false;
-
-        measurementData.invalidated = true;
-
-        external.cornerstone.updateImage(element);
-
-        const activeTool = getActiveTool(element, buttons, interactionType);
-
-        if (activeTool instanceof baseAnnotationTool) {
-          activeTool.updateCachedStats(image, element, measurementData);
-        }
-
-        const modifiedEventData = {
-          toolType: this.name,
-          element,
-          measurementData,
-        };
-
-        triggerEvent(element, EVENTS.MEASUREMENT_MODIFIED, modifiedEventData);
-        triggerEvent(element, EVENTS.MEASUREMENT_COMPLETED, modifiedEventData);
-
-        // send imex finish event
-        const eventType = EVENTS.MEASUREMENT_FINISHED;
-        if (measurementData.complete) {
-          const endEventData = {
-            toolType: this.name,
-            element: element,
-            measurementData: measurementData
-          };
-          triggerEvent(element, eventType, endEventData);
-        }
-      },
-    },
-    interactionType
+      // send imex finish event
+      triggerEvent(element, EVENTS.MEASUREMENT_FINISHED, endEventData);
+      external.cornerstone.updateImage(element);
+    }
   );
 }
 

--- a/src/tools/parallelDistanceTool/addNewMeasurement.js
+++ b/src/tools/parallelDistanceTool/addNewMeasurement.js
@@ -39,52 +39,18 @@ export default function(evt, interactionType) {
     this.name,
     measurementData,
     end,
-    {
-      doneMovingCallback: () => {
-        const { handles, longestDiameter, shortestDiameter } = measurementData;
-        const hasHandlesOutside = anyHandlesOutsideImage(eventData, handles);
-        const longestDiameterSize = parseFloat(longestDiameter) || 0;
-        const shortestDiameterSize = parseFloat(shortestDiameter) || 0;
-        const isTooSmal = longestDiameterSize < 1 || shortestDiameterSize < 1;
-        const isTooFast = new Date().getTime() - timestamp < 150;
+    () => {      
+      const endEventData = {
+        toolType: this.name,
+        element: element,
+        measurementData: measurementData
+      };
+      triggerEvent(element, EVENTS.MEASUREMENT_COMPLETED, endEventData);
 
-        if (hasHandlesOutside || isTooSmal || isTooFast) {
-          // Delete the measurement
-          measurementData.cancelled = true;
-          removeToolState(element, this.name, measurementData);
-        } else {
-          // Set lesionMeasurementData Session
-          config.getMeasurementLocationCallback(
-            measurementData,
-            eventData,
-            doneCallback
-          );
-        }
-
-        // Perpendicular line is not connected to long-line
-        perpendicularStart.locked = false;
-
-        measurementData.invalidated = true;
-
-        external.cornerstone.updateImage(element);
-
-        const activeTool = getActiveTool(element, buttons, interactionType);
-
-        if (activeTool instanceof baseAnnotationTool) {
-          activeTool.updateCachedStats(image, element, measurementData);
-        }
-
-        const modifiedEventData = {
-          toolType: this.name,
-          element,
-          measurementData,
-        };
-
-        triggerEvent(element, EVENTS.MEASUREMENT_MODIFIED, modifiedEventData);
-        triggerEvent(element, EVENTS.MEASUREMENT_COMPLETED, modifiedEventData);
-      },
-    },
-    interactionType
+      // send imex finish event
+      triggerEvent(element, EVENTS.MEASUREMENT_FINISHED, endEventData);
+      external.cornerstone.updateImage(element);
+    }
   );
 }
 


### PR DESCRIPTION
Fix:
- el método doneMoveCallback no se creaba de forma adecuada y, como consecuencia, los eventos no eran generados. Esto incluye el evento MEASUREMENT_FINISHED usado para coordinar el funcionamiento del "candado".